### PR TITLE
Avoid string concatenation in loop for performance reason

### DIFF
--- a/src/main/java/io/github/ikegamiyukino/neologdn/NeologdNormalizer.java
+++ b/src/main/java/io/github/ikegamiyukino/neologdn/NeologdNormalizer.java
@@ -131,7 +131,7 @@ public class NeologdNormalizer {
     }
 
     public String normalize(String sentence) {
-        String result = "";
+        StringBuilder result = new StringBuilder();
         Character prev = ' ';
         boolean latinSpace = false;
 
@@ -144,7 +144,7 @@ public class NeologdNormalizer {
                     continue;
                 } else if (prev != '*' && i > 0 && basicLatin.contains(prev)) {
                     latinSpace = true;
-                    result += current;
+                    result.append(current);
                 }
             } else {
                 if (hiphens.contains(current)) {
@@ -152,37 +152,37 @@ public class NeologdNormalizer {
                         continue;
                     } else {
                         current = '-';
-                        result += current;
+                        result.append(current);
                     }
                 } else if (choonpus.contains(current)) {
                     if (prev == 'ー') {
                         continue;
                     } else {
                         current = 'ー';
-                        result += current;
+                        result.append(current);
                     }
                 } else if (tildes.contains(current)) {
                     continue;
                 } else {
                     if (current == 'ﾞ' && kana_ten_map.containsKey(prev)) {
-                        result = result.substring(0, result.length()-1);
+                        result.deleteCharAt(result.length()-1);
                         current = kana_ten_map.get(prev);
                     } else if (current == 'ﾟ' && kana_maru_map.containsKey(prev)) {
-                        result = result.substring(0, result.length()-1);
+                        result.deleteCharAt(result.length()-1);
                         current = kana_maru_map.get(prev);
                     } else if (conversion_map.containsKey(current)) {
                         current = conversion_map.get(current);
                     }
                     if (latinSpace && jpChars.contains(current)) {
-                        result = result.substring(0, result.length()-1);
+                        result.deleteCharAt(result.length()-1);
                     }
                     latinSpace = false;
-                    result += current;
+                    result.append(current);
                 }
             }
             prev = current;
         }
-        return result;
+        return result.toString();
     }
 
     public static Set<Character> charsFromRange(int start, int end) {


### PR DESCRIPTION
String concatenation in loop generates new string for each loop, which makes time complexity O(length^2).

This becomes a problem when input text is long.

We can make time complexity O(length) by using StringBuilder.

時間計算量を削減する変更です。エッジケースなので、殆どの場合は問題にならないと思います。

# Test

```
StringBuilder inputStringBuilder = new StringBuilder();
for (int i = 0; i < 1000000; i++) {
    inputStringBuilder.append("- ");
}
String inputString = inputStringBuilder.toString();

NeologdNormalizer normalizer = new NeologdNormalizer();

long start = System.currentTimeMillis();
normalizer.normalize(inputString);
long end = System.currentTimeMillis();

System.out.println(1.0 * (end - start) / 1000);
```

using String -> 230.288
using StringBuilder -> 0.089
